### PR TITLE
Move check-release script into a container

### DIFF
--- a/containers/check-release/Dockerfile
+++ b/containers/check-release/Dockerfile
@@ -1,0 +1,32 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM registry.fedoraproject.org/fedora:41
+
+RUN \
+  dnf -y --quiet --repo=fedora install \
+    diff \
+    gpg \
+    msidiff \
+    rpmsign \
+    wget
+
+RUN \
+  wget https://downloads.apache.org/daffodil/KEYS && \
+  gpg --import KEYS
+
+# Install and set the entrypoint
+COPY src/check-release.sh /usr/bin/daffodil-check-release
+ENTRYPOINT ["/usr/bin/daffodil-check-release"]

--- a/containers/check-release/README.md
+++ b/containers/check-release/README.md
@@ -1,0 +1,43 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+## Daffodil Check Release Container
+
+This container can be used to verify the signatures, checksums, signatures, and
+optionally reproducibility.
+
+Note that it is possible to run the src/check-release.sh script standalone
+without the container, but the container proviedes an environment that has all
+the necessary dependencies and keys already installed, so it may make release
+verification easier.
+
+To build or update the build release container image:
+
+    podman build -t daffodil-check-release containers/check-release/
+
+To use the container image to check a release, run the following:
+
+    podman run -it --rm \
+      daffodil-check-release "$DIST_URL" "$MAVEN_URL"
+
+Alternatively, if you would like to do the same checks but also check for
+reproducibility, use the Release Candidate Container to build a release
+directory directory, then run the following:
+
+    podman run -it --rm \
+      --volume <RELEASE_DIR>:/release
+      daffodil-check-release "<DIST_URL>" "<MAVEN_URL>" /release

--- a/containers/check-release/src/check-release.sh
+++ b/containers/check-release/src/check-release.sh
@@ -1,4 +1,19 @@
 #!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 if [[ "$#" -lt "2" || "$#" -gt 3 ]]
 then
@@ -35,7 +50,7 @@ then
 	require_command rpmsign
 fi
 
-WGET="wget --no-verbose --force-progress --recursive --level=inf -e robots=off --no-parent --no-host-directories --reject=index.html,robots.txt"
+WGET="wget --recursive --level=inf -e robots=off --no-parent --no-host-directories --reject=index.html,robots.txt"
 
 RELEASE_DIR=release-download
 DIST_DIR=$RELEASE_DIR/asf-dist


### PR DESCRIPTION
The check release script requires a number of tools that might not be avilable on some systems. To make it easier to test on those, this moves the check-release script into a container that includes all the necessary dependencies.

Note that the script can still be run without the container if the tools exist on the system, so having the ability to run containers is not strictly required to run the verification script. And most tools the script uses can be installed on most systems. The one exception is msidiff which is only needed to check build reproducibility. This also removes options from wget that are not necessary and aren't available on all versions of wget, making it easier to run the script without a container.

DAFFODIL-2972