### PR TITLE
Fix directory where we create release sha512sum files

### DIFF
--- a/actions/release-candidate/dist/post/index.js
+++ b/actions/release-candidate/dist/post/index.js
@@ -125544,7 +125544,7 @@ async function run() {
 						stdout: (data) => { checksum += data.toString(); }
 					}
 				});
-				fs.appendFileSync(`${ artifact.name }.sha512`, checksum);
+				fs.appendFileSync(`${ artifact.parentPath }/${ artifact.name }.sha512`, checksum);
 				await exec("gpg", ["--default-key", gpg_signing_key_id, "--batch", "--yes", "--detach-sign", "--armor", "--output", `${ artifact.name }.asc`, artifact.name], {
 					cwd: artifact.parentPath
 				});

--- a/actions/release-candidate/src/post.js
+++ b/actions/release-candidate/src/post.js
@@ -51,7 +51,7 @@ async function run() {
 						stdout: (data) => { checksum += data.toString(); }
 					}
 				});
-				fs.appendFileSync(`${ artifact.name }.sha512`, checksum);
+				fs.appendFileSync(`${ artifact.parentPath }/${ artifact.name }.sha512`, checksum);
 				await exec("gpg", ["--default-key", gpg_signing_key_id, "--batch", "--yes", "--detach-sign", "--armor", "--output", `${ artifact.name }.asc`, artifact.name], {
 					cwd: artifact.parentPath
 				});


### PR DESCRIPTION
Accidentally left off arfifact.parentPath so sha512sum files were created but not in the correct directory where the artifact lives.

DAFFODIL-2971