### PR TITLE
Use Java 17 for building Raffodil release candidates

### DIFF
--- a/containers/build-release/Dockerfile
+++ b/containers/build-release/Dockerfile
@@ -40,6 +40,7 @@ RUN \
     llvm \
     npm \
     openjdk-8-jdk-headless \
+    openjdk-17-jdk-headless \
     rpm \
     unzip \
     wine32 \

--- a/containers/build-release/src/daffodil-build-release
+++ b/containers/build-release/src/daffodil-build-release
@@ -17,6 +17,21 @@
 
 set -e
 
+set_java_version() {
+  # There are a number of standard ways to change the java version. One is to
+  # set JAVA_HOME and PATH, but its possible a build tool could execute
+  # /usr/bin/java* directly and use the wrong version. Another option is to use
+  # update-alternatives, but that needs slightly different commands for java 8
+  # vs java 17, so would make this function more complicated. Instead, we just
+  # manually overwrite the java* bin symlinks. This is really only fine because
+  # this is always expected to be run in a container.
+  JAVA_BIN_ROOT="/usr/lib/jvm/java-$1-openjdk-amd64/bin"
+  ln -sf $JAVA_BIN_ROOT/java    /usr/bin/java
+  ln -sf $JAVA_BIN_ROOT/javac   /usr/bin/javac
+  ln -sf $JAVA_BIN_ROOT/javadoc /usr/bin/javadoc
+  ln -sf $JAVA_BIN_ROOT/jar     /usr/bin/jar
+}
+
 export WIX=/opt/wix/
 export LANG=en_US.UTF-8
 export CC=clang
@@ -65,6 +80,7 @@ echo "==== Building binary artifacts ===="
 
 case $PROJECT in
   "daffodil")
+    set_java_version 17
     mkdir -p $DIST_DIR/bin
     sbt \
       +compile \
@@ -82,12 +98,14 @@ case $PROJECT in
     ;;
 
   "daffodil-sbt")
+    set_java_version 8
     sbt \
       "^compile" \
       "^publish"
     ;;
 
   "daffodil-vscode")
+    set_java_version 8
     mkdir -p $DIST_DIR/bin/
     yarn package
     cp *.vsix $DIST_DIR/bin/


### PR DESCRIPTION
The VS Code extension and SBT plugin still support Java 8, so we install both jdk8 and jdk17 and then add a new function to set all java binaries use the correct version.

DAFFODIL-3017