### PR TITLE
Improve checking of RPM reproducibility

### DIFF
--- a/containers/check-release/Dockerfile
+++ b/containers/check-release/Dockerfile
@@ -19,7 +19,6 @@ RUN \
   dnf -y --quiet --repo=fedora install \
     diff \
     gpg \
-    rpmsign \
     wget
 
 RUN \


### PR DESCRIPTION
When dist RPMs are created, they are signed with an embedded signature. This can make reproducibility difficult. To handle this, we currently use rpmsign --delsign to delete the embedded signatures before performing the diff. But rpmsign --delsign sometimes deletes the signature in a way that is technically correct in that the RPM does not have a signature, but the RPM is still not identical to the same RPM that was never signed.

To allow for checking reproducibility, this replaces the delsign logic with a custom function that just copies the signature header from the locally built RPM to the dist RPM. This ensures the signatures headers are exactly the same, and allows us to ensure all other bytes are identical.

This no longer needs the rpmsign command and is removed from the container and command checks.

DAFFODIL-3037