### PR TITLE
Change check-release container to Ubuntu

### DIFF
--- a/containers/check-release/Dockerfile
+++ b/containers/check-release/Dockerfile
@@ -13,12 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM registry.fedoraproject.org/fedora:41
+FROM docker.io/library/ubuntu:22.04
 
 RUN \
-  dnf -y --quiet --repo=fedora install \
-    cmp \
+  apt-get update && \
+  apt-get install -qy \
+    diffutils \
     gpg \
+    rpm \
     wget
 
 RUN \

--- a/containers/check-release/src/check-release.sh
+++ b/containers/check-release/src/check-release.sh
@@ -45,6 +45,11 @@ download_dir() {
 		--reject=index.html,robots.txt \
 		--cut-dirs=$CUT_DIRS \
 		"$URL"
+
+	# wget on some systems (e.g. Ubuntu 22.04) leaves behind .tmp files used
+	# when downloading files, likely related to --reject=index.html. Delete
+	# those if they exist.
+	find "$(basename "$URL")" -name '*.tmp' -delete
 }
 
 # URL of release candidate directory in dev/dist/, e.g. https://dist.apache.org/repos/dist/dev/daffodil/1.0.0-rc1


### PR DESCRIPTION
Something with the Fedora check-release container can lead to issues with gpg validation, something about lock files alreay existing and timing out. It isn't clear exactly what the problem is, but it does not occur on Ubuntu. So this switches the check-release container to Ubuntu. This also makes it consistent with the build-release container which is also Ubuntu based so they can share the same base image.

The only issue with this is Ubuntu wget seems to create index.html.tmp files that it doesn't delete--other systems do delete these files. This seems to be a known issue with some versions of wget, so we just delete any tmp files if they exist. This is also useful in cases where users directly run the script on Ubuntu systems without the container.