### PR TITLE
Do not include existing SVN artifacts in uploaded zip

### DIFF
--- a/actions/release-candidate/dist/main/index.js
+++ b/actions/release-candidate/dist/main/index.js
@@ -31931,7 +31931,14 @@ async function run() {
 			publish = false;
 		}
 
-		const release_dir = `${ os.tmpdir() }/release`;
+		// the name of the directory where we store release artifacts doesn't actually
+		// matter since it is never published anywhere. The one time where this isn't true
+		// is if publishing is disabled, in which case this directory is made available as
+		// a downloadable GitHub artifact. Naming it "release-download" makes it more
+		// clear this is a downloaded artifact rather than locally built--this
+		// differentiates it from artifacts created with the build-release container and
+		// follows the naming convention expected by the check-release script.
+		const release_dir = `${ os.tmpdir() }/release-download`;
 		fs.mkdirSync(release_dir);
 
 		// enable and configure SBT for signing and publishing. Note that the

--- a/actions/release-candidate/dist/post/index.js
+++ b/actions/release-candidate/dist/post/index.js
@@ -125557,14 +125557,18 @@ async function run() {
 		} else {
 			// if publishing was disabled then this action was likely just triggered
 			// just for testing, so upload the maven-local and artifact directories so
-			// they can be verified
-			const release_dir = `${ os.tmpdir() }/release`;
-			const upload_artifacts = fs.readdirSync(release_dir, { recursive: true, withFileTypes: true })
+			// they can be verified. Note that we do not just recurse the
+			// release-download directory since it could contain files that already
+			// exist in the SVN checkout and were not artifacts created by this action
+			const release_dir = `${ os.tmpdir() }/release-download`;
+			const svn_artifacts = fs.readdirSync(artifact_dir, { recursive: true, withFileTypes: true });
+			const maven_artifacts = fs.readdirSync(`${ release_dir }/maven-local`, { recursive: true, withFileTypes: true });
+			const upload_artifacts = [...svn_artifacts, ...maven_artifacts]
 				.filter((dirent) => dirent.isFile())
 				.filter((dirent) => !dirent.parentPath.split("/").includes(".svn"))
 				.map((dirent) => `${ dirent.parentPath }/${ dirent.name }`);
 			const artifact_client = new DefaultArtifactClient();
-			artifact_client.uploadArtifact(`release`, upload_artifacts, os.tmpdir(), {
+			artifact_client.uploadArtifact("release-download", upload_artifacts, os.tmpdir(), {
 				compressionLevel: 0,
 				retentionDays: 1
 			});

--- a/actions/release-candidate/src/main.js
+++ b/actions/release-candidate/src/main.js
@@ -102,7 +102,14 @@ async function run() {
 			publish = false;
 		}
 
-		const release_dir = `${ os.tmpdir() }/release`;
+		// the name of the directory where we store release artifacts doesn't actually
+		// matter since it is never published anywhere. The one time where this isn't true
+		// is if publishing is disabled, in which case this directory is made available as
+		// a downloadable GitHub artifact. Naming it "release-download" makes it more
+		// clear this is a downloaded artifact rather than locally built--this
+		// differentiates it from artifacts created with the build-release container and
+		// follows the naming convention expected by the check-release script.
+		const release_dir = `${ os.tmpdir() }/release-download`;
 		fs.mkdirSync(release_dir);
 
 		// enable and configure SBT for signing and publishing. Note that the


### PR DESCRIPTION
When the release-cadidate action does not publish a release (e.g. snapshot build, triggered fromh workflow_dispatch), the action creates a zip of the created artifacts so that they can be verified. However, it can also include artifacts that already existed in SVN. This can lead to confusion since there are unexpected files. This fixes the logic of how we list artifacts to ensure we only include artifacts that were created by the action so it excludes files that were already in SVN.

This also renames the "release" directory where artifacts are stored to "release-download"--this makes its naming more clear that the zip contains downloaded artifacts rather that locally built artifacts, and makes the naming working better with the check-release container.

DAFFODIL-3040