### PR TITLE
Ensure SBT release builds are built on Java 17

### DIFF
--- a/containers/build-release/Dockerfile
+++ b/containers/build-release/Dockerfile
@@ -39,7 +39,6 @@ RUN \
     libmxml-dev \
     llvm \
     npm \
-    openjdk-8-jdk-headless \
     openjdk-17-jdk-headless \
     rpm \
     unzip \

--- a/containers/build-release/src/daffodil-build-release
+++ b/containers/build-release/src/daffodil-build-release
@@ -107,7 +107,7 @@ case $PROJECT in
     ;;
 
   "daffodil-sbt")
-    set_java_version 8
+    set_java_version 17
     sbt \
       "^compile" \
       "^publish"


### PR DESCRIPTION
Daffodil 4.0.0 and newer requires a minimum of Java 17 to build, so we must build on Java 17. Note that the plugin class files are built with Java 8 compatibility so the plugin still works on older versions of Java. It is only the Daffodil Saver components used when daffodilVersion is 4.0.0 or newer where the classes are built with Java 17.