### PR TITLE
Set max-parallel for all GitHub action jobs

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -30,6 +30,8 @@ jobs:
 
   check-dist:
     runs-on: ubuntu-22.04
+    strategy:
+      max-parallel: 1
 
     steps:
 


### PR DESCRIPTION
In accordance with ASF policy, set job.strategy.max-parallel to the recommended 15 or less. Most values are set to 1, except for when there are matrices, in which case the value is set to the number of expected jobs for the matrix, with a maximum of 15.

DAFFODIL-3069