### PR TITLE
Switch to using temurin JDK with build-release

### DIFF
--- a/containers/build-release/Dockerfile
+++ b/containers/build-release/Dockerfile
@@ -39,19 +39,23 @@ RUN \
     libmxml-dev \
     llvm \
     npm \
-    openjdk-17-jdk-headless \
     rpm \
     unzip \
     wine32 \
     winetricks \
     xvfb && \
-  echo "deb https://repo.scala-sbt.org/scalasbt/debian all main" > /etc/apt/sources.list.d/sbt.list && \
+  echo "deb [signed-by=/etc/apt/trusted.gpg.d/scalasbt-release.gpg] https://repo.scala-sbt.org/scalasbt/debian all main" > /etc/apt/sources.list.d/sbt.list && \
   curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823" | \
     gpg --no-default-keyring --keyring gnupg-ring:/etc/apt/trusted.gpg.d/scalasbt-release.gpg --import && \
   chmod 644 /etc/apt/trusted.gpg.d/scalasbt-release.gpg && \
+  echo "deb [siged-by=/etc/apt/trusted.gpg.d/adoptium.gpg] https://packages.adoptium.net/artifactory/deb jammy main" > /etc/apt/sources.list.d/adoptium.list && \
+  curl -sL "https://packages.adoptium.net/artifactory/api/gpg/key/public" | \
+    gpg --no-default-keyring --keyring gnupg-ring:/etc/apt/trusted.gpg.d/adoptium.gpg --import && \
+  chmod 644 /etc/apt/trusted.gpg.d/adoptium.gpg && \
   apt-get update && \
   apt-get install -y \
-    sbt && \
+    sbt \
+    temurin-17-jdk && \
   npm --no-update-notifier install --global yarn@1.22.19 node@20
 
 # Download and install Inno Setup via wine. Even though we provide options to

--- a/containers/build-release/src/daffodil-build-release
+++ b/containers/build-release/src/daffodil-build-release
@@ -18,18 +18,7 @@
 set -e
 
 set_java_version() {
-  # There are a number of standard ways to change the java version. One is to
-  # set JAVA_HOME and PATH, but its possible a build tool could execute
-  # /usr/bin/java* directly and use the wrong version. Another option is to use
-  # update-alternatives, but that needs slightly different commands for java 8
-  # vs java 17, so would make this function more complicated. Instead, we just
-  # manually overwrite the java* bin symlinks. This is really only fine because
-  # this is always expected to be run in a container.
-  JAVA_BIN_ROOT="/usr/lib/jvm/java-$1-openjdk-amd64/bin"
-  ln -sf $JAVA_BIN_ROOT/java    /usr/bin/java
-  ln -sf $JAVA_BIN_ROOT/javac   /usr/bin/javac
-  ln -sf $JAVA_BIN_ROOT/javadoc /usr/bin/javadoc
-  ln -sf $JAVA_BIN_ROOT/jar     /usr/bin/jar
+  update-java-alternatives --set temurin-$1-jdk-amd64
 }
 
 export WIX=/opt/wix/


### PR DESCRIPTION
The Daffodil Github Actions release candidate workflows use temurin JDK for all builds, but our build-release container uses the Debian packaged JDK. Although these should be pretty much the same and so far it has not led to any differences, the purpose of the build-release container is to build something as close as possible to the Github Actions artifacts. This switch to using temurin for the build-release candidate to remove any potential differences.

This also uses update-java-alternatives to switch between java versions, which is a better option than our previous approach now that we always use temurin and its consisted naming conventions.

Also updates the sbt apt config to ensure we only use sbt keys for verifying sbt packages, following best practices.