### PR TITLE
Support checking reproducible builds against released repositories

### DIFF
--- a/containers/build-release/README.md
+++ b/containers/build-release/README.md
@@ -26,21 +26,28 @@ To build or update the build release container image:
 
     podman build -t daffodil-build-release containers/build-release/
 
-To use the container image to build a release, run the following from the root
-of the project git repository, replacing `<REPO_DIR>` with the path to the git
-repository of the project to build and `<ARTIFACT_DIR>` with the directory
-where you want the artifacts saved:
+To use the container image to build a release, run:
 
-    podman run -it --rm \
-      --hostname daffodil.build \
-      --volume <REPO_DIR>:/project:O \
-      --volume <ARTIFACT_DIR>:/artifacts \
-      daffodil-build-release
+```
+podman run -it --rm \
+  --hostname daffodil.build \
+  --volume <REPO_DIR>:/project:O \
+  --volume <ARTIFACT_DIR>:/artifacts \
+  daffodil-build-release <PROJECT_NAME> <PRE_RELEASE_LABEL>
+```
+
+Replace the placeholders as follows:
+
+* `<REPO_DIR>` - path to the git repository of the project to build
+* `<ARTIFACT_DIR>` - path to the directory where you want the artifacts saved
+* `<PROJECT_NAME>` - name of the project (e.g. `daffodil`).
+* `<PRE_RELEASE_LABEL>` - label of the release candidate (e.g. `rc1`). This
+  argument is optional and can be left off to build artifacts to compare
+  against a final release
 
 Note that the `<REPO_DIR>` volume uses the `:O` suffix so that changes to the
 repository inside the container do not affect the repository outside the
 container.
 
-When run, the container will ask for an optional pre-release label (e.g. rc1)
-and the project to build. The resulting artifacts will be written to the
+When run, the resulting artifacts will be written to the
 `<ARTIFACT_DIR>/release/` directory.

--- a/containers/check-release/Dockerfile
+++ b/containers/check-release/Dockerfile
@@ -19,6 +19,7 @@ RUN \
   apt-get update && \
   apt-get install -qy \
     diffutils \
+    lftp \
     gpg \
     rpm \
     wget

--- a/containers/check-release/README.md
+++ b/containers/check-release/README.md
@@ -17,7 +17,7 @@
 
 ## Daffodil Check Release Container
 
-This container can be used to verify the signatures, checksums, signatures, and
+This container can be used to verify the signatures, checksums, and
 optionally reproducibility.
 
 Note that it is possible to run the src/check-release.sh script standalone
@@ -32,12 +32,19 @@ To build or update the build release container image:
 To use the container image to check a release, run the following:
 
     podman run -it --rm \
-      daffodil-check-release "$DIST_URL" "$MAVEN_URL"
+      daffodil-check-release "<VERSION>" "<DIST_URL>" "<MAVEN_URL>"
 
 Alternatively, if you would like to do the same checks but also check for
-reproducibility, use the Release Candidate Container to build a release
+reproducibility, use the Build Release Container to build a `release/`
 directory, then run the following:
 
     podman run -it --rm \
       --volume <RELEASE_DIR>:/release \
-      daffodil-check-release "<DIST_URL>" "<MAVEN_URL>" /release
+      daffodil-check-release "<VERSION>" "<DIST_URL>" "<MAVEN_URL>" /release
+
+Replace the placeholders as follows:
+
+* `<VERSION>` - version of the release, excluding any pre-release labels (e.g. `1.0.0`)
+* `<DIST_URL>` - URL to ASF download dist directory for the release (e.g. `https://dist.apache.org/repos/dist/dev/daffodil/1.0.0-rc1`)
+* `<MAVEN_URL>` - URL to ASF staging or release repository (e.g. `https://repository.apache.org/content/repositories/orgapachedaffodil-1234`)
+

--- a/containers/check-release/src/check-release.sh
+++ b/containers/check-release/src/check-release.sh
@@ -87,48 +87,46 @@ download_dir() {
 	# non-greedily delete the schema and domain part of the URL, giving just
 	# the path part
 	URL_PATH="${URL#*://*/}"
-	# we want to use --cut-dirs to ignore all directories but the final target
-	# directory. This number is different depending on the URL, so we extract
-	# and count the nubmer of slash-separated fields of the url path and
-	# subtract 2 (one because we want to keep the last field, and one because
-	# there is an extra field because the path ends in a slash)
-	CUT_DIRS=$(echo "$URL_PATH" | awk -F/ '{print NF - 2}')
-	wget \
-		--recursive \
-		--level=inf \
-		-e robots=off \
-		--no-parent \
-		--no-host-directories \
-		--reject=index.html,robots.txt \
-		--cut-dirs=$CUT_DIRS \
-		"$URL"
 
+	# loop through the filter path parameter, path step by path step, to build
+	# up a list of --include-glob options to provide to lftp. This is necessary
+	# to prevent lftp from traversing and mirroring directories that we don't
+	# need. This is especially useful when downloading releases from
+	# non-staging ASF or maven repositories. Defaults to * if not provided
+	FILTER_PATH="${2:-*}"
+	INCLUDE_GLOBS=""
+	CURRENT_PATH=""
+	IFS='/' read -ra STEPS <<< "$FILTER_PATH"
+	for STEP in "${STEPS[@]}"; do
+		CURRENT_PATH="${CURRENT_PATH:+$CURRENT_PATH/}$STEP"
+		INCLUDE_GLOBS+="--include-glob=$CURRENT_PATH --include-glob=$CURRENT_PATH/ "
+	done
+
+	lftp -c "mirror --parallel --no-empty-dirs --exclude-glob=* $INCLUDE_GLOBS $URL"
 	RC=$?
 	if [ $RC -ne 0 ]; then
 		print_result $RC "Failed to download URL: $URL" >&2
 		exit 1
 	fi
-
-	# wget on some systems (e.g. Ubuntu 22.04) leaves behind .tmp files used
-	# when downloading files, likely related to --reject=index.html. Delete
-	# those if they exist.
-	find "$(basename "$URL")" -name '*.tmp' -delete
 }
 
 
 usage() {
-	echo "Usage: $0 <DIST_URL> <MAVEN_URL> [LOCAL_RELEASE_DIR]" >&2
+	echo "Usage: $0 <VERSION> <DIST_URL> <MAVEN_URL> [LOCAL_RELEASE_DIR]" >&2
 }
 
-if [[ "$#" -lt "2" || "$#" -gt 3 ]]
+if [[ "$#" -lt "3" || "$#" -gt 4 ]]
 then
 	echo "error: incorrect number of arguments" >&2
 	usage
 	exit 1
 fi
 
+# Version to check the release for
+VERSION=$1
+
 # URL of release candidate directory in dist/dev, e.g. https://dist.apache.org/repos/dist/dev/daffodil/1.0.0-rc1
-DIST_URL=$1
+DIST_URL=$2
 if [ -z "$DIST_URL" ]
 then
   echo "error: DIST_URL parameter must not be empty" >&2
@@ -136,12 +134,12 @@ then
   exit 1
 fi
 
-# URL of maven staging repository, e.g. https://repository.apache.org/content/repositories/orgapachedaffodil-1234
-MAVEN_URL=$2
+# URL of maven repository, e.g. https://repository.apache.org/content/repositories/orgapachedaffodil-1234
+MAVEN_URL=$3
 
 # optional path to release directory built by running the daffodil-build-release
 # container. If not provided, only signature/checksum checks are done
-LOCAL_RELEASE_DIR=$3
+LOCAL_RELEASE_DIR=$4
 
 require_command() {
 	command -v "$1" &> /dev/null || { echo "error: command $1 not found in PATH"; exit 1; }
@@ -154,7 +152,7 @@ require_command md5sum
 require_command rpm
 require_command sha1sum
 require_command sha512sum
-require_command wget
+require_command lftp
 
 
 RELEASE_DIR=release-download
@@ -162,34 +160,32 @@ DIST_DIR=$RELEASE_DIR/asf-dist
 MAVEN_DIR=$RELEASE_DIR/maven-local
 
 
+printf "\n==== Downloading Release Files ====\n"
 if [ ! -d "$RELEASE_DIR" ]
 then
-	printf "\n==== Downloading Release Files ====\n"
-
 	# download dist/dev/ files
-	mkdir -p $DIST_DIR
-	pushd $DIST_DIR &>/dev/null
-	download_dir $DIST_URL
+	mkdir -p "$DIST_DIR"
+	pushd "$DIST_DIR" &>/dev/null
+	download_dir "$DIST_URL"
 	popd &>/dev/null
 
-	# download maven repository, delete nexus generated files, and remove the
-	# orgapachedaffodil-1234 dir since the build-release container does not have
-	# this directory
+	# download artifacts from the maven repository, and remove the root
+	# directory (e.g. orgapachedaffodil-1234) since the build-release container
+	# does not have this directory
 	if [ -n "$MAVEN_URL" ]
 	then
-		mkdir -p $MAVEN_DIR
-		pushd $MAVEN_DIR &>/dev/null
-		download_dir $MAVEN_URL
-		find . -type f \( -name 'archetype-catalog.xml' -o -name 'maven-metadata.xml*' \) -delete
+		mkdir -p "$MAVEN_DIR"
+		pushd "$MAVEN_DIR" &>/dev/null
+		download_dir "$MAVEN_URL" "org/apache/daffodil/*/$VERSION/*"
 		REPO_DIR=(*/)
-		mv $REPO_DIR/* .
-		rmdir $REPO_DIR
+		mv "$REPO_DIR"/* .
+		rmdir "$REPO_DIR"
 		popd &>/dev/null
 	fi
 
-	printf "\n==== Download Complete ====\n"
+	echo -e "$PASS download complete"
 else
-	printf "\n==== Skipping Download, release-download/ directory already exists ====\n"
+	echo -e "$WARN skipping download, release-download/ directory already exists"
 fi
 
 printf "\n==== Dist SHA512 Checksum ====\n"


### PR DESCRIPTION
Currently the check-release script only works against staging maven repositories. This is somewhat limiting since it makes it difficult to confirm that final releases are reproducible after published to maven.

To fix this, this modifies the check-release script to use lftp instead of wget to download release artifacts. This makes the script a bit more complex, but lftp is has much less verbose output and is more powerful than wget, with native support for downloading http indexes and better filter/glob support. The download_dir function adds a new argument that allows specifying a glob of files that should be downloaded. This allows setting MAVEN_URL to an ASF or maven central URL and and only traversing needed directories without mirroring everything.

Also updates messages related to download to make it more clear when downloading files succeeded or was skipped.

Also updates the READMEs based on new usage. The build-release container no longer asks the user for input, instead input must be provides as options